### PR TITLE
Show "Reconnecting..." when disconnected

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -41,6 +41,7 @@ export type SpectateStore = {
   isDebug: boolean;
   isFullscreen: boolean;
   watchingLive: boolean;
+  disconnected: boolean;
 };
 
 export type SpectateData = {

--- a/src/components/common/icons.tsx
+++ b/src/components/common/icons.tsx
@@ -381,6 +381,31 @@ export function LiveIcon(props: IconProps) {
   );
 }
 
+export function ReconnectingText(props: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="180"
+      height="40"
+      viewBox="0 0 180 40"
+      {...props}
+    >
+      <title>{props.title}</title>
+      <text
+        x="50%"
+        y="50%"
+        dominant-baseline="middle"
+        text-anchor="middle"
+        font-family="sans-serif"
+        font-size="24"
+        font-weight="bold"
+      >
+        Reconnecting...
+      </text>
+    </svg>
+  )
+}
+
 // Comfortaa from Google Fonts
 export function SlippiLab(props: IconProps) {
   return (

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -6,7 +6,7 @@ import { Stage } from "~/components/viewer/Stage";
 import { Item } from "~/components/viewer/Item";
 import { SpectateControls } from "~/components/viewer/SpectateControls";
 import { Controls } from "~/components/viewer/Controls";
-import { LiveIcon } from "~/components/common/icons";
+import { LiveIcon, ReconnectingText } from "~/components/common/icons";
 import { nonReactiveState, spectateStore } from "~/state/spectateStore";
 import { access, replayPointer } from "~/state/accessor";
 
@@ -31,11 +31,19 @@ export function Viewer() {
       <div class="flex flex-col overflow-y-auto relative">
         <Show
           when={access("settings") && access("frames").length > access("frame")} // this is really spectate-only behavior
-          fallback={<div class="flex justify-center italic">Waiting for game...</div>}
+          fallback={<div class="flex justify-center italic">{access("disconnected") ? "Reconnecting..." : "Waiting for game..."}</div>}
         >
-          <Show when={access("watchingLive")}>
-            <LiveIcon title="Live" class="absolute top-4 left-4 w-12" />
+          <Show
+            when={access("disconnected")}
+            fallback={
+              <Show when={access("watchingLive")}>
+                <LiveIcon title="Live" class="absolute top-4 left-4 w-12" />
+              </Show>
+            }
+          >
+            <ReconnectingText title="Reconnecting" class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 fill-red-500 stroke-red-600" />
           </Show>
+
           <Show when={!access("isLoading")} fallback={<div class="flex justify-center italic">Loading...</div>}>
             <svg class="rounded-t border bg-slate-50" viewBox="-365 -300 730 600">
               {/* up = positive y axis */}

--- a/src/state/accessor.ts
+++ b/src/state/accessor.ts
@@ -13,7 +13,7 @@ type ReplayPointer = {
 };
 
 type ViewerMode = "replay" | "spectate";
-type ViewerStateAttribute = "settings" | "ending" | "frames" | "replayFormatVersion" | "animations" | "isLoading" | "frame" | "renderDatas" | "framesPerTick" | "running" | "zoom" | "isDebug" | "isFullscreen" | "watchingLive" | "currentFrame";
+type ViewerStateAttribute = "settings" | "ending" | "frames" | "replayFormatVersion" | "animations" | "isLoading" | "frame" | "renderDatas" | "framesPerTick" | "running" | "zoom" | "isDebug" | "isFullscreen" | "watchingLive" | "disconnected" | "currentFrame";
 
 type API = {
   replayPointer(): ReplayPointer | null,
@@ -110,6 +110,10 @@ export function access(attribute: ViewerStateAttribute): any {
     "watchingLive": {
       "replay": () => false,
       "spectate": () => spectateStore.watchingLive
+    },
+    "disconnected": {
+      "replay": () => false,
+      "spectate": () => spectateStore.disconnected
     }
   };
 

--- a/src/state/spectateStore.tsx
+++ b/src/state/spectateStore.tsx
@@ -46,7 +46,8 @@ export const defaultSpectateStoreState: SpectateStore = {
   zoom: 1,
   isDebug: false,
   isFullscreen: false,
-  watchingLive: true
+  watchingLive: true,
+  disconnected: false
 };
 
 const BUFFER_FRAME_COUNT = 2;
@@ -165,6 +166,10 @@ const [running, start, stop] = createRAF(
   )
 );
 createEffect(() => setReplayState("running", running()));
+
+export function setDisconnected(disconnected: boolean): void {
+  setReplayState("disconnected", disconnected);
+}
 
 export function setReplayStateFromGameEvent(gameEvent: GameEvent): void {
   switch (gameEvent.type) {

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -47,13 +47,20 @@ function connectWS(wsUrl: string) {
     handleGameData(msg.data);
   };
 
-  ws.onerror = (err) => {
-    console.error("WebSocket error:", err);
+  ws.onopen = () => {
+    postMessage({ type: "connected", value: null });
+    console.log("WebSocket opened");
   }
 
+  ws.onerror = (err) => {
+    postMessage({ type: "disconnected", value: "error" });
+    console.error("WebSocket error:", err);
+  };
+
   ws.onclose = (msg) => {
+    postMessage({ type: "disconnected", value: "closed" });
     console.log("WebSocket closed:", msg);
-  }
+  };
 }
 
 function handleGameData(payload: ArrayBuffer) {


### PR DESCRIPTION
This PR has the worker send messages about the WebSocket connection status to the main thread. This gives the user indication of whether it's known that something has gone wrong.

Note that at this time, the UI does not differentiate between close and error types. The known issue where ReconnectingWebsocket does not attempt to reconnect will mistakenly show "Reconnecting..." for now, but this PR paves the way to tell the user to refresh the page (or even better, to auto-reset the whole connection).